### PR TITLE
Hideable default values

### DIFF
--- a/Axodox.Common.Shared/Json/JsonArray.cpp
+++ b/Axodox.Common.Shared/Json/JsonArray.cpp
@@ -98,4 +98,9 @@ namespace Axodox::Json
       return false;
     }
   }
+
+  bool json_array::is_default() const
+  {
+    return value.empty();
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonArray.h
+++ b/Axodox.Common.Shared/Json/JsonArray.h
@@ -19,6 +19,8 @@ namespace Axodox::Json
 
     json_array_iterator begin() const;
     json_array_iterator end() const;
+
+    virtual bool is_default() const override;
   };
 
   template <typename value_t>

--- a/Axodox.Common.Shared/Json/JsonBoolean.cpp
+++ b/Axodox.Common.Shared/Json/JsonBoolean.cpp
@@ -46,4 +46,9 @@ namespace Axodox::Json
       return false;
     }
   }
+
+  bool json_boolean::is_default() const
+  {
+    return !value;
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonBoolean.h
+++ b/Axodox.Common.Shared/Json/JsonBoolean.h
@@ -10,6 +10,8 @@ namespace Axodox::Json
 
     virtual void to_string(std::stringstream& stream) const override;
     static Infrastructure::value_ptr<json_boolean> from_string(std::string_view& text);
+
+    virtual bool is_default() const override;
   };
 
   template <>

--- a/Axodox.Common.Shared/Json/JsonNull.cpp
+++ b/Axodox.Common.Shared/Json/JsonNull.cpp
@@ -28,4 +28,9 @@ namespace Axodox::Json
       return nullptr;
     }
   }
+
+  bool json_null::is_default() const
+  {
+    return true;
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonNull.h
+++ b/Axodox.Common.Shared/Json/JsonNull.h
@@ -11,5 +11,7 @@ namespace Axodox::Json
 
     virtual void to_string(std::stringstream& stream) const override;
     static Infrastructure::value_ptr<json_null> from_string(std::string_view& text);
+
+    virtual bool is_default() const override;
   };
 }

--- a/Axodox.Common.Shared/Json/JsonNumber.cpp
+++ b/Axodox.Common.Shared/Json/JsonNumber.cpp
@@ -25,4 +25,9 @@ namespace Axodox::Json
       return nullptr;
     }
   }
+
+  bool json_number::is_default() const
+  {
+    return value == 0;
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonNumber.h
+++ b/Axodox.Common.Shared/Json/JsonNumber.h
@@ -13,6 +13,8 @@ namespace Axodox::Json
 
     virtual void to_string(std::stringstream& stream) const override;
     static Infrastructure::value_ptr<json_number> from_string(std::string_view& text);
+
+    virtual bool is_default() const override;
   };
 
   template <typename value_t>

--- a/Axodox.Common.Shared/Json/JsonObject.cpp
+++ b/Axodox.Common.Shared/Json/JsonObject.cpp
@@ -116,4 +116,9 @@ namespace Axodox::Json
       return false;
     }
   }
+
+  bool json_object::is_default() const
+  {
+    return value.empty();
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonObject.h
+++ b/Axodox.Common.Shared/Json/JsonObject.h
@@ -19,7 +19,9 @@ namespace Axodox::Json
 
     virtual void to_string(std::stringstream& stream) const override;
     static Infrastructure::value_ptr<json_object> from_string(std::string_view& text);
-        
+
+    virtual bool is_default() const override;
+
     void set_value(const char* key, Infrastructure::value_ptr<json_value>&& json)
     {
       this->value[key] = std::move(json);

--- a/Axodox.Common.Shared/Json/JsonSchema.h
+++ b/Axodox.Common.Shared/Json/JsonSchema.h
@@ -90,6 +90,7 @@ namespace Axodox::Json
       _serialize([=](const void* object) { return converter_t::to_json(static_cast<const object_t*>(object)->*field); }),
       _deserialize([=](void* object, const json_value* json) { return converter_t::from_json(json, static_cast<object_t*>(object)->*field); }),
       _isDefaultValue([](const json_value* value) {
+        if (!value) return true;
         if constexpr (Infrastructure::is_instantiation_of_v<std::optional, value_t>)
         {
           return value->type() == json_type::null;

--- a/Axodox.Common.Shared/Json/JsonSchema.h
+++ b/Axodox.Common.Shared/Json/JsonSchema.h
@@ -51,7 +51,7 @@ namespace Axodox::Json
   public:
     json_type type() const { return _type; }
     const char* name() const { return _name; }
-    std::optional<bool> is_required() const { return _isRequired; }
+    std::optional<bool> is_required() const { return _is_required; }
 
     Infrastructure::value_ptr<json_value> to_json(const void* object) const
     {
@@ -65,7 +65,7 @@ namespace Axodox::Json
 
     bool is_default_value(const json_value* value) const
     {
-      return _isDefaultValue(value);
+      return _is_default_value(value);
     }
 
     const json_object_schema_base* schema() const
@@ -83,13 +83,13 @@ namespace Axodox::Json
     //the field's owner type at compile time. The void*-erased lambdas assume the field's owner
     //sits at offset 0 of whichever object_t is later passed in (single-inheritance hierarchies).
     template<typename object_t, typename value_t, typename converter_t = json_serializer<value_t>>
-    json_property_descriptor_base(value_t object_t::* field, const char* name, std::optional<bool> isRequired = std::nullopt, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
+    json_property_descriptor_base(value_t object_t::* field, const char* name, std::optional<bool> is_required = std::nullopt, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
       _type(schema.type),
       _name(name),
-      _isRequired(isRequired),
+      _is_required(is_required),
       _serialize([=](const void* object) { return converter_t::to_json(static_cast<const object_t*>(object)->*field); }),
       _deserialize([=](void* object, const json_value* json) { return converter_t::from_json(json, static_cast<object_t*>(object)->*field); }),
-      _isDefaultValue([](const json_value* value) {
+      _is_default_value([](const json_value* value) {
         if (!value) return true;
         if constexpr (Infrastructure::is_instantiation_of_v<std::optional, value_t>)
         {
@@ -107,10 +107,10 @@ namespace Axodox::Json
   private:
     json_type _type;
     const char* _name;
-    std::optional<bool> _isRequired;
+    std::optional<bool> _is_required;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _serialize;
     std::function<bool(void*, const json_value*)> _deserialize;
-    std::function<bool(const json_value*)> _isDefaultValue;
+    std::function<bool(const json_value*)> _is_default_value;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _describe;
     Infrastructure::void_ptr _schema;
   };
@@ -125,8 +125,8 @@ namespace Axodox::Json
     { }
 
     template<typename value_t, typename converter_t = json_serializer<value_t>>
-    json_property_descriptor(value_t object_t::* field, const char* name, std::optional<bool> isRequired, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
-      json_property_descriptor_base(field, name, isRequired, schema, converter)
+    json_property_descriptor(value_t object_t::* field, const char* name, std::optional<bool> is_required, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
+      json_property_descriptor_base(field, name, is_required, schema, converter)
     { }
   };
 

--- a/Axodox.Common.Shared/Json/JsonSchema.h
+++ b/Axodox.Common.Shared/Json/JsonSchema.h
@@ -51,6 +51,7 @@ namespace Axodox::Json
   public:
     json_type type() const { return _type; }
     const char* name() const { return _name; }
+    std::optional<bool> is_required() const { return _isRequired; }
 
     Infrastructure::value_ptr<json_value> to_json(const void* object) const
     {
@@ -77,19 +78,20 @@ namespace Axodox::Json
     //the field's owner type at compile time. The void*-erased lambdas assume the field's owner
     //sits at offset 0 of whichever object_t is later passed in (single-inheritance hierarchies).
     template<typename object_t, typename value_t, typename converter_t = json_serializer<value_t>>
-    json_property_descriptor_base(value_t object_t::* field, const char* name, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
+    json_property_descriptor_base(value_t object_t::* field, const char* name, std::optional<bool> isRequired = std::nullopt, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
       _type(schema.type),
       _name(name),
+      _isRequired(isRequired),
       _serialize([=](const void* object) { return converter_t::to_json(static_cast<const object_t*>(object)->*field); }),
       _deserialize([=](void* object, const json_value* json) { return converter_t::from_json(json, static_cast<object_t*>(object)->*field); }),
       _describe([](const void* schema) { return static_cast<const json_schema_type<value_t>*>(schema)->to_json(); }),
       _schema(schema)
-    {
-    }
+    { }
 
   private:
     json_type _type;
     const char* _name;
+    std::optional<bool> _isRequired;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _serialize;
     std::function<bool(void*, const json_value*)> _deserialize;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _describe;
@@ -102,16 +104,19 @@ namespace Axodox::Json
   public:
     template<typename value_t, typename converter_t = json_serializer<value_t>>
     json_property_descriptor(value_t object_t::* field, const char* name, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
-      json_property_descriptor_base(field, name, schema, converter)
-    {
-    }
+      json_property_descriptor(field, name, std::nullopt, schema, converter)
+    { }
+
+    template<typename value_t, typename converter_t = json_serializer<value_t>>
+    json_property_descriptor(value_t object_t::* field, const char* name, std::optional<bool> isRequired, const json_schema_type<value_t>& schema = {}, converter_t converter = {}) :
+      json_property_descriptor_base(field, name, isRequired, schema, converter)
+    { }
   };
 
   struct json_object_options
   {
     const char* name = nullptr;
     const char* description = nullptr;
-    const char* required = nullptr;
     const char* type_discriminator = nullptr;
   };
 
@@ -141,7 +146,6 @@ namespace Axodox::Json
       json_object_descriptor result;
       result._name = options.name;
       result.description = options.description;
-      result.required = options.required;
       result._type_discriminator = options.type_discriminator ? options.type_discriminator : "$type";
       result._instantiate = []() -> std::unique_ptr<object_t> { return std::make_unique<object_t>(); };
 
@@ -201,7 +205,10 @@ namespace Axodox::Json
     {
       for (auto& property : _properties)
       {
-        json->set_value(property.name(), property.to_json(&object));
+        auto value = property.to_json(&object);
+        if (property.is_required() == false && value->is_default()) continue;
+
+        json->set_value(property.name(), value);
       }
     }
 
@@ -408,12 +415,12 @@ namespace Axodox::Json
   struct json_object_schema : public json_type_schema<json_object_schema<object_t>, json_type::object>
   {
     const char* description = nullptr;
-    const char* required = nullptr;
 
     void populate_schema(json_object& schema) const
     {
       if (description) schema.set_value("description", description);
 
+      std::stringstream required;
       if constexpr (described_json_object<object_t>)
       {
         const json_object_descriptor<object_t>& objectDescription = object_t::json_description;
@@ -425,11 +432,17 @@ namespace Axodox::Json
         for (auto& property : objectDescription.properties())
         {
           properties->set_value(property.name(), property.to_json_schema());
+
+          if (property.is_required())
+          {
+            if (required.tellp() > 0) required << ',';
+            required << property.name();
+          }
         }
         schema.set_value("properties", Infrastructure::value_ptr<json_value>(std::move(properties)));
       }
 
-      if (required) schema.set_value("required", Infrastructure::split(required, ','));
+      if (required.tellp() > 0) schema.set_value("required", required.str());
     }
   };
 #pragma endregion

--- a/Axodox.Common.Shared/Json/JsonSchema.h
+++ b/Axodox.Common.Shared/Json/JsonSchema.h
@@ -63,6 +63,11 @@ namespace Axodox::Json
       return _deserialize(object, json);
     }
 
+    bool is_default_value(const json_value* value) const
+    {
+      return _isDefaultValue(value);
+    }
+
     const json_object_schema_base* schema() const
     {
       return static_cast<const json_object_schema_base*>(_schema.get());
@@ -84,6 +89,16 @@ namespace Axodox::Json
       _isRequired(isRequired),
       _serialize([=](const void* object) { return converter_t::to_json(static_cast<const object_t*>(object)->*field); }),
       _deserialize([=](void* object, const json_value* json) { return converter_t::from_json(json, static_cast<object_t*>(object)->*field); }),
+      _isDefaultValue([](const json_value* value) {
+        if constexpr (Infrastructure::is_instantiation_of_v<std::optional, value_t>)
+        {
+          return value->type() == json_type::null;
+        }
+        else
+        {
+          return value->is_default();
+        }
+      }),
       _describe([](const void* schema) { return static_cast<const json_schema_type<value_t>*>(schema)->to_json(); }),
       _schema(schema)
     { }
@@ -94,6 +109,7 @@ namespace Axodox::Json
     std::optional<bool> _isRequired;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _serialize;
     std::function<bool(void*, const json_value*)> _deserialize;
+    std::function<bool(const json_value*)> _isDefaultValue;
     std::function<Infrastructure::value_ptr<json_value>(const void*)> _describe;
     Infrastructure::void_ptr _schema;
   };
@@ -206,7 +222,7 @@ namespace Axodox::Json
       for (auto& property : _properties)
       {
         auto value = property.to_json(&object);
-        if (property.is_required() == false && value->is_default()) continue;
+        if (property.is_required() == false && property.is_default_value(value.get())) continue;
 
         json->set_value(property.name(), value);
       }

--- a/Axodox.Common.Shared/Json/JsonString.cpp
+++ b/Axodox.Common.Shared/Json/JsonString.cpp
@@ -117,4 +117,9 @@ namespace Axodox::Json
       return false;
     }
   }
+
+  bool json_string::is_default() const
+  {
+    return value.empty();
+  }
 }

--- a/Axodox.Common.Shared/Json/JsonString.h
+++ b/Axodox.Common.Shared/Json/JsonString.h
@@ -11,6 +11,8 @@ namespace Axodox::Json
 
     virtual void to_string(std::stringstream& stream) const override;
     static Infrastructure::value_ptr<json_string> from_string(std::string_view& text);
+
+    virtual bool is_default() const override;
   };
 
   template <>

--- a/Axodox.Common.Shared/Json/JsonValue.h
+++ b/Axodox.Common.Shared/Json/JsonValue.h
@@ -30,6 +30,8 @@ namespace Axodox::Json
     std::string to_string() const;
 
     static Infrastructure::value_ptr<json_value> from_string(std::string_view& text);
+
+    virtual bool is_default() const = 0;
   };
 
   template<typename value_t, json_type json_type_c>

--- a/Axodox.Common.Tests/JsonTest.cpp
+++ b/Axodox.Common.Tests/JsonTest.cpp
@@ -559,6 +559,8 @@ namespace Axodox::Common::Tests
 
     TEST_METHOD(TestTypelessValueSerialization)
     {
+      TestSerialization("{}");
+      TestSerialization("null");
       TestSerialization("1.14");
       TestSerialization("true");
       TestSerialization("\"asd\"");
@@ -656,6 +658,11 @@ namespace Axodox::Common::Tests
         hidden_defaults_test_object source;
         source.nullable = "x";
         Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"null default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.nullable = "";
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"null default-skipping when value is default broken");
       }
     }
 

--- a/Axodox.Common.Tests/JsonTest.cpp
+++ b/Axodox.Common.Tests/JsonTest.cpp
@@ -195,6 +195,23 @@ namespace
       { &unspecified_required_test_object::text,   "text" }
       });
 
+    struct any_visible_variations_object
+    {
+      static json_object_descriptor<any_visible_variations_object> json_description;
+
+      value_ptr<json_value> any;
+      value_ptr<json_value> unrequied_any;
+      optional<value_ptr<json_value>> optional_any;
+      optional<value_ptr<json_value>> unrequired_optional_any;
+    };
+
+    json_object_descriptor<any_visible_variations_object> any_visible_variations_object::json_description = describe_json_object<any_visible_variations_object>({
+      { &any_visible_variations_object::any, "any" },
+      { &any_visible_variations_object::unrequied_any, "unrequied_any", false },
+      { &any_visible_variations_object::optional_any, "optional_any" },
+      { &any_visible_variations_object::unrequired_optional_any,"unrequired_optional_any", false }
+      });
+
     json_object* as_object(const value_ptr<json_value>& v)
     {
       Assert::IsNotNull(v.get(), L"json value is null");
@@ -684,6 +701,56 @@ namespace Axodox::Common::Tests
       auto* root = as_object(schema);
       json_value* required;
       Assert::IsFalse(root->try_get_value("required", required), L"schema must not list a required property when none are explicitly required");
+    }
+
+    TEST_METHOD(TestAnyVisibilityVariations)
+    {
+      auto any_default_value = try_parse_json<value_ptr<json_value>>("0");
+      auto any_value = try_parse_json<value_ptr<json_value>>("1");
+
+      {
+        any_visible_variations_object variations;
+
+        auto json = stringify_json(variations);
+        auto parsed = try_parse_json<json_object>(json);
+        Assert::IsTrue(parsed.has_value(), L"any_visible_variations_object failed to parse");
+        Assert::IsTrue(parsed->value.contains("any"));
+        Assert::IsFalse(parsed->value.contains("unrequied_any"));
+        Assert::IsTrue(parsed->value.contains("optional_any"));
+        Assert::IsFalse(parsed->value.contains("unrequired_optional_any"));
+      }
+
+      {
+        any_visible_variations_object variations;
+        variations.any = *any_default_value;
+        variations.unrequied_any = *any_default_value;
+        variations.optional_any = *any_default_value;
+        variations.unrequired_optional_any = *any_default_value;
+
+        auto json = stringify_json(variations);
+        auto parsed = try_parse_json<json_object>(json);
+        Assert::IsTrue(parsed.has_value(), L"any_visible_variations_object failed to parse");
+        Assert::IsTrue(parsed->value.contains("any"));
+        Assert::IsFalse(parsed->value.contains("unrequied_any"));
+        Assert::IsTrue(parsed->value.contains("optional_any"));
+        Assert::IsTrue(parsed->value.contains("unrequired_optional_any"));
+      }
+
+      {
+        any_visible_variations_object variations;
+        variations.any = *any_value;
+        variations.unrequied_any = *any_value;
+        variations.optional_any = *any_value;
+        variations.unrequired_optional_any = *any_value;
+
+        auto json = stringify_json(variations);
+        auto parsed = try_parse_json<json_object>(json);
+        Assert::IsTrue(parsed.has_value(), L"any_visible_variations_object failed to parse");
+        Assert::IsTrue(parsed->value.contains("any"));
+        Assert::IsTrue(parsed->value.contains("unrequied_any"));
+        Assert::IsTrue(parsed->value.contains("optional_any"));
+        Assert::IsTrue(parsed->value.contains("unrequired_optional_any"));
+      }
     }
   };
 }

--- a/Axodox.Common.Tests/JsonTest.cpp
+++ b/Axodox.Common.Tests/JsonTest.cpp
@@ -154,9 +154,45 @@ namespace
     };
 
     json_object_descriptor<typeless_test_object> typeless_test_object::json_description = describe_json_object<typeless_test_object>({
-      { &typeless_test_object::optional_object, "optional_object", {.description = "An optional object.", .required = "some_prop"}},
+      { &typeless_test_object::optional_object, "optional_object", {.description = "An optional object." }},
       { &typeless_test_object::any_value,       "any_value",       {.description = "Any value." }},
       { &typeless_test_object::some_array,      "some_array",      {.description = "An array.", .max_items = 10 }}
+      });
+
+    struct hidden_defaults_test_object
+    {
+      static json_object_descriptor<hidden_defaults_test_object> json_description;
+
+      bool flag = false;
+      int number = 0;
+      string text;
+      vector<int> items;
+      json_object object;
+      std::optional<string> nullable;
+    };
+
+    json_object_descriptor<hidden_defaults_test_object> hidden_defaults_test_object::json_description = describe_json_object<hidden_defaults_test_object>({
+      { &hidden_defaults_test_object::flag,     "flag",     false },
+      { &hidden_defaults_test_object::number,   "number",   false },
+      { &hidden_defaults_test_object::text,     "text",     false },
+      { &hidden_defaults_test_object::items,    "items",    false },
+      { &hidden_defaults_test_object::object,   "object",   false },
+      { &hidden_defaults_test_object::nullable, "nullable", false }
+      });
+
+    struct unspecified_required_test_object
+    {
+      static json_object_descriptor<unspecified_required_test_object> json_description;
+
+      bool flag = false;
+      int number = 0;
+      string text;
+    };
+
+    json_object_descriptor<unspecified_required_test_object> unspecified_required_test_object::json_description = describe_json_object<unspecified_required_test_object>({
+      { &unspecified_required_test_object::flag,   "flag" },
+      { &unspecified_required_test_object::number, "number" },
+      { &unspecified_required_test_object::text,   "text" }
       });
 
     json_object* as_object(const value_ptr<json_value>& v)
@@ -547,7 +583,100 @@ namespace Axodox::Common::Tests
       TestSerialization<typeless_test_object>("{\"optional_object\":{\"a\":5.6,\"b\":true},\"any_value\":1.2,\"some_array\":[1,2,3,false,\"asd\"]}");
 
       auto schema = typeless_test_object::json_description.to_json()->to_string();
-      Assert::AreEqual<string_view>("{\"type\":\"object\",\"properties\":{\"optional_object\":{\"type\":\"object\",\"description\":\"An optional object.\",\"required\":[\"some_prop\"]},\"any_value\":{\"description\":\"Any value.\"},\"some_array\":{\"type\":\"array\",\"description\":\"An array.\",\"maxItems\":10,\"items\":{}}}}", schema);
+      Assert::AreEqual<string_view>("{\"type\":\"object\",\"properties\":{\"optional_object\":{\"type\":\"object\",\"description\":\"An optional object.\"},\"any_value\":{\"description\":\"Any value.\"},\"some_array\":{\"type\":\"array\",\"description\":\"An array.\",\"maxItems\":10,\"items\":{}}}}", schema);
+    }
+
+    TEST_METHOD(TestHiddenDefaultsAllSkippedWhenDefault)
+    {
+      // Every property is required=false, every field carries its type's default value:
+      // bool=false, number=0, string="", array=[], object={}, optional=nullopt(null).
+      hidden_defaults_test_object source;
+      auto json = stringify_json(source);
+      Assert::AreEqual<string_view>("{}", json);
+    }
+
+    TEST_METHOD(TestHiddenDefaultsNonDefaultsRetained)
+    {
+      hidden_defaults_test_object source;
+      source.flag = true;
+      source.number = 42;
+      source.text = "hi";
+      source.items = { 1, 2 };
+      source.object.set_value("k", string("v"));
+      source.nullable = "set";
+
+      auto json = stringify_json(source);
+      auto parsed = try_parse_json<hidden_defaults_test_object>(json);
+      Assert::IsTrue(parsed.has_value(), L"hidden_defaults_test_object failed to round-trip");
+      Assert::IsTrue(parsed->flag);
+      Assert::AreEqual(42, parsed->number);
+      Assert::AreEqual(string("hi"), parsed->text);
+      Assert::AreEqual(size_t(2), parsed->items.size());
+      Assert::IsTrue(parsed->object.value.contains("k"));
+      Assert::IsTrue(parsed->nullable.has_value());
+      Assert::AreEqual(string("set"), parsed->nullable.value());
+    }
+
+    TEST_METHOD(TestHiddenDefaultsPerTypeIndividually)
+    {
+      // Flipping one field at a time should make exactly that one field appear in the JSON.
+      auto property_count = [](const string& json)
+      {
+        auto parsed = try_parse_json<json_object>(json);
+        Assert::IsTrue(parsed.has_value(), L"json_object parse failed");
+        return parsed->value.size();
+      };
+
+      {
+        hidden_defaults_test_object source;
+        source.flag = true;
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"bool default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.number = 1;
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"number default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.text = "x";
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"string default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.items = { 1 };
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"array default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.object.set_value("k", string("v"));
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"object default-skipping broken");
+      }
+      {
+        hidden_defaults_test_object source;
+        source.nullable = "x";
+        Assert::AreEqual(size_t(1), property_count(stringify_json(source)), L"null default-skipping broken");
+      }
+    }
+
+    TEST_METHOD(TestUnspecifiedRequiredSerializesAllAndSchemaRequiresNone)
+    {
+      // Properties without an explicit `required` flag should always serialize,
+      // even when their values match the type's default.
+      unspecified_required_test_object source;
+      auto json = stringify_json(source);
+      auto parsed_object = try_parse_json<json_object>(json);
+      Assert::IsTrue(parsed_object.has_value(), L"unspecified_required object failed to parse");
+      Assert::AreEqual(size_t(3), parsed_object->value.size(), L"all properties should serialize when required is unset");
+      Assert::IsTrue(parsed_object->value.contains("flag"));
+      Assert::IsTrue(parsed_object->value.contains("number"));
+      Assert::IsTrue(parsed_object->value.contains("text"));
+
+      // The schema must not declare any property as required.
+      auto schema = unspecified_required_test_object::json_description.to_json();
+      auto* root = as_object(schema);
+      json_value* required;
+      Assert::IsFalse(root->try_get_value("required", required), L"schema must not list a required property when none are explicitly required");
     }
   };
 }


### PR DESCRIPTION
Extend the required functionality by checking against default values of the json_types and omitting the properties with default values if they are not required.
Added logic to handle when an optional is not required, in which case only null should be considered default.